### PR TITLE
Feature/allow container upgrades

### DIFF
--- a/charts/cyclecloud/templates/Deployment.yaml
+++ b/charts/cyclecloud/templates/Deployment.yaml
@@ -46,6 +46,15 @@ spec:
           value: "{{ .Values.cycle.userPubKey }}"
         - name: CYCLECLOUD_RESOURCE_GROUP
           value: "{{ .Values.cycle.resourceGroup }}"
+        - name: CYCLECLOUD_HOSTNAME
+          value: "{{ .Values.cycle.webServerHostname }}"
+        {{- if eq .Values.cycle.configureDefaultAccount false }}
+        - name: NO_DEFAULT_ACCOUNT
+          value: "--noDefaultAccount"
+        {{- else }}
+        - name: WILL_CONFIGURE_DEFAULT_ACCOUNT
+          value: "Will configure default CycleCloud account {{.Values.cycle.configureDefaultAccount}} : {{(eq .Values.cycle.configureDefaultAccount false)}}."
+        {{- end }}
         image: "{{ .Values.cycle.containerImage }}"
         resources:
           requests:

--- a/charts/cyclecloud/templates/Deployment.yaml
+++ b/charts/cyclecloud/templates/Deployment.yaml
@@ -80,8 +80,9 @@ spec:
           periodSeconds: 10
 
         volumeMounts:
-        - mountPath: "/opt"
+        - mountPath: "/opt/cycle_server/data"
           name: cyclecloud-data-volume
+
       volumes:
       - name: cyclecloud-data-volume
         persistentVolumeClaim:

--- a/charts/cyclecloud/templates/PersistentVolumeClaim.yaml
+++ b/charts/cyclecloud/templates/PersistentVolumeClaim.yaml
@@ -10,4 +10,4 @@ spec:
   storageClassName: managed-premium-retain
   resources:
     requests:
-      storage: 128Gi
+      storage: {{ .Values.cycle.dataDiskSize }}

--- a/charts/cyclecloud/templates/Service.yaml
+++ b/charts/cyclecloud/templates/Service.yaml
@@ -4,18 +4,24 @@ metadata:
   name: {{ include "cyclecloud.fullname" . }}
   labels:
     {{- include "cyclecloud.labels" . | nindent 4 }}
+  # Comment out annotations to create a Public IP
   annotations:
     service.beta.kubernetes.io/azure-load-balancer-internal: "true"
 spec:
   type: {{ .Values.service.type }}
   ports:
+  # Enable HTTP port for LetsEncrypt support
+  # - protocol: TCP
+  #   port: 80
+  #   targetPort: {{ .Values.cycle.webServerPort }}
+  #   name: webserverport
   - protocol: TCP
     port: {{ .Values.service.port }}
-    targetPort: 8443
+    targetPort: {{ .Values.cycle.webServerSslPort }}
     name: webserversslport
   - protocol: TCP
     port: 9443
-    targetPort: 9443
+    targetPort: {{ .Values.cycle.webServerClusterPort }}
     name: webserverclusterport
   selector:
     {{- include "cyclecloud.selectorLabels" . | nindent 4 }}

--- a/charts/cyclecloud/templates/StorageClass.yaml
+++ b/charts/cyclecloud/templates/StorageClass.yaml
@@ -7,3 +7,4 @@ reclaimPolicy: Delete
 parameters:
   storageaccounttype: Standard_LRS
   kind: Managed
+

--- a/charts/cyclecloud/values.yaml
+++ b/charts/cyclecloud/values.yaml
@@ -12,8 +12,13 @@ cycle:
   
   uid: 1169
   gid: 1169
-  username: 123
-  password: 123
+  username: cc_admin
+  password: 
+  webServerHostname: 
+  webServerPort: 8080
+  webServerSslPort: 443
+  webServerClusterPort: 9443
+  configureDefaultAccount: true
   storage: 123
   userPubKey: 123
   resourceGroup: 123

--- a/charts/cyclecloud/values.yaml
+++ b/charts/cyclecloud/values.yaml
@@ -7,6 +7,8 @@ azureIdentity:
 
 cycle:
   replicas: 1
+  dataDiskSize: 128Gi
+  backupsDiskSize: 128Gi
   
   uid: 1169
   gid: 1169

--- a/docker/cyclecloud8/Dockerfile
+++ b/docker/cyclecloud8/Dockerfile
@@ -4,7 +4,6 @@ WORKDIR /cs-install
 ENV CS_UID 1169
 ENV CS_GID 1169
 ENV CS_ROOT /opt/cycle_server
-ENV BACKUPS_DIRECTORY /azurecyclecloud
 
 ADD https://aka.ms/downloadazcopy-v10-linux /tmp/azcopy_linux.tar.gz
 
@@ -31,7 +30,8 @@ RUN yum update -y \
     && yum install -y azure-cli \
     && tar xzf /tmp/azcopy_linux.tar.gz -C /tmp/ \
     && mv /tmp/azcopy_linux*/azcopy /usr/local/bin/azcopy \
-    && rm -rf /tmp/azcopy_linux*
+    && rm -rf /tmp/azcopy_linux* \
+    && alternatives --set python /usr/bin/python3
 
 RUN groupadd -g ${CS_GID} cycle_server \
     && useradd -u ${CS_UID} -g ${CS_GID} -m -d /opt/cycle_server cycle_server \
@@ -46,14 +46,19 @@ RUN groupadd -g ${CS_GID} cycle_server \
     && cd /tmp/cyclecloud-cli-installer \
     && /tmp/cyclecloud-cli-installer/install.sh --system \
     && rm -rf /tmp/cyclecloud-cli-installer \
-    && alternatives --set python /usr/bin/python3
-    && echo "Caching cycle_server install in container..." \
-    && mkdir -p /opt_cycle_server \
-    && mv /opt/cycle_server /opt_cycle_server/ \
-    && chmod 777 /opt \
-    && chown cycle_server:cycle_server /opt \
-    && chown -R cycle_server:cycle_server /opt_cycle_server
+    && touch /opt/cycle_server/data/ads/initial_load.marker \
+    && chown cycle_server:cycle_server /opt/cycle_server/data/ads/initial_load.marker
+    
+# Stash a copy the cycle_server/data/ads directory to allow mounting a persistent volume at data/ or data/ads 
+# If an empty volume is mounted, we'll copy the initial data directory back to the volume
+RUN echo "Stashing a copy of the cycle_server data directory..." \
+    && mkdir -p /opt_cycle_server/  \
+    && cp -a /opt/cycle_server/data /opt_cycle_server/  \
+    && chown -R cycle_server:cycle_server /opt_cycle_server  \
+    && ls -ltra  /opt_cycle_server/data/ads/
 
+# NOTE: we remove the "ads" directory to assist in choosing when to 'restore' from backup vs just restarting
+#       this way, if the master.logfile exists, we know we should simply restart
 
 ADD ./scripts /cs-install/scripts
 RUN chown -R cycle_server:cycle_server /cs-install

--- a/docker/cyclecloud8/Dockerfile.ubuntu
+++ b/docker/cyclecloud8/Dockerfile.ubuntu
@@ -30,6 +30,7 @@ RUN apt update -y \
 RUN groupadd -g ${CS_GID} cycle_server \
     && useradd -u ${CS_UID} -g ${CS_GID} -m -d /opt/cycle_server cycle_server \
     && apt install -y cyclecloud8 \
+    && /opt/cycle_server/cycle_server await_startup \
     && /opt/cycle_server/cycle_server stop \
     && sed -i 's/webServerMaxHeapSize\=2048M/webServerMaxHeapSize\=4096M/' /opt/cycle_server/config/cycle_server.properties \
     && sed -i 's/webServerPort\=8080/webServerPort\=8080/' /opt/cycle_server/config/cycle_server.properties \

--- a/docker/cyclecloud8/Dockerfile.ubuntu
+++ b/docker/cyclecloud8/Dockerfile.ubuntu
@@ -4,7 +4,6 @@ WORKDIR /cs-install
 ENV CS_UID 1169
 ENV CS_GID 1169
 ENV CS_ROOT /opt/cycle_server
-ENV BACKUPS_DIRECTORY /azurecyclecloud
 
 ARG DEBIAN_FRONTEND=noninteractive
 ADD https://aka.ms/downloadazcopy-v10-linux /tmp/azcopy_linux.tar.gz
@@ -17,13 +16,15 @@ RUN apt update -y \
 
 RUN apt update -y \
     && wget -qO - https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
-    && echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ bionic main" > /etc/apt/sources.list.d/azure-cli.list \
+    && echo "deb [arch=amd64] https://packages.microsoft.com/repos/azure-cli/ $(lsb_release -cs) main" > /etc/apt/sources.list.d/azure-cli.list \
     && apt -y update \
     && apt install -y azure-cli \
     && tar xzf /tmp/azcopy_linux.tar.gz -C /tmp/ \
     && mv /tmp/azcopy_linux*/azcopy /usr/local/bin/azcopy \
     && rm -rf /tmp/azcopy_linux* \
     && echo "deb https://packages.microsoft.com/repos/cyclecloud bionic main" > /etc/apt/sources.list.d/cyclecloud.list \
+    && apt install -y python3-venv \
+    && update-alternatives --install /usr/bin/python python /usr/bin/python3 1 \
     && apt -y update
 
 RUN groupadd -g ${CS_GID} cycle_server \
@@ -34,20 +35,21 @@ RUN groupadd -g ${CS_GID} cycle_server \
     && sed -i 's/webServerPort\=8080/webServerPort\=8080/' /opt/cycle_server/config/cycle_server.properties \
     && sed -i 's/webServerSslPort\=8443/webServerSslPort\=8443/' /opt/cycle_server/config/cycle_server.properties \
     && sed -i 's/webServerEnableHttps\=false/webServerEnableHttps=true/' /opt/cycle_server/config/cycle_server.properties \
-    && apt install -y python3-venv \
     && cd /tmp \
     && unzip /opt/cycle_server/tools/cyclecloud-cli.zip \
     && cd /tmp/cyclecloud-cli-installer \
     && /tmp/cyclecloud-cli-installer/install.sh --system \
     && rm -rf /tmp/cyclecloud-cli-installer \
-    && update-alternatives --install /usr/bin/python python /usr/bin/python3 1 \
-    && echo "Caching cycle_server install in container..." \
-    && mkdir -p /opt_cycle_server \
-    && mv /opt/cycle_server /opt_cycle_server/ \
-    && chmod 777 /opt \
-    && chown cycle_server:cycle_server /opt \
-    && chown -R cycle_server:cycle_server /opt_cycle_server
-
+    && touch /opt/cycle_server/data/ads/initial_load.marker \
+    && chown cycle_server:cycle_server /opt/cycle_server/data/ads/initial_load.marker
+    
+# Stash a copy the cycle_server/data/ads directory to allow mounting a persistent volume at data/ or data/ads 
+# If an empty volume is mounted, we'll copy the initial data directory back to the volume
+RUN echo "Stashing a copy of the cycle_server data directory..." \
+    && mkdir -p /opt_cycle_server/  \
+    && cp -a /opt/cycle_server/data /opt_cycle_server/  \
+    && chown -R cycle_server:cycle_server /opt_cycle_server  \
+    && ls -ltra  /opt_cycle_server/data/ads/
 
 ADD ./scripts /cs-install/scripts
 RUN chown -R cycle_server:cycle_server /cs-install

--- a/docker/cyclecloud8/scripts/run_cyclecloud.sh
+++ b/docker/cyclecloud8/scripts/run_cyclecloud.sh
@@ -2,17 +2,65 @@
 set -x
 set -e
 
-# If CycleCloud install was locally cached, move it into place now...
-# Useful in locked-down environments where yum is blocked
-if [ ! -d "/opt/cycle_server" ] && [ -d "/opt_cycle_server/cycle_server" ]; then
-   echo "Moving cyclecloud install from container to persistent disk on first start..."
-   mv /opt_cycle_server/cycle_server /opt/cycle_server
-else
-   rm -rf /opt_cycle_server/cycle_server
+CS_ROOT="/opt/cycle_server"
+
+# If CycleCloud data dir was locally stashed, and mounted data dir is empty
+# then this is the first load with a persistent volume, so copy stashed data into place
+# (Move files within the ads/ directory rather than director itself to allow mounting at ads/)
+if [ ! -f "${CS_ROOT}/data/ads/master.logfile" ]; then
+   echo "Moving stashed cyclecloud data from container to mounted data disk on first start..."
+   rm -rf ${CS_ROOT}/data/ads/*
+   mkdir -p ${CS_ROOT}/data/ads
+   mv /opt_cycle_server/data/ads/* ${CS_ROOT}/data/ads/
 fi
 
+
+# If no datastore exists, check if a backup exists and restore
+# GOAL: allow mounting ${CS_ROOT}/data to either persistent or ephemeral disk
+#       allow independently mounting ${CS_ROOT}/data/backups to a separate persistent volume if desired
+# RATIONALE:
+# Managed Disk is not currently Zone Redundant, so to achieve Zonal Failover, place backups on slower
+#   zone-redundant remote storage such as Azure Files (alternatively find a remote storage option that is 
+#   performant enough for the entire ${CS_ROOT}/data directory...)
+NUM_BACKUPS=$(ls -d -1 ${CS_ROOT}/data/backups/backup-* 2>/dev/null | wc -l )
+NEEDS_RESTORE="false"
+
+# if [ -f ${CS_ROOT}/data/ads/master.logfile ]; then
+#     echo "Restarting from valid CycleCloud logfile, no restore required."
+#     NEEDS_RESTORE="false"
+# elif [ -d ${CS_ROOT}/data/backups ] && [ ${NUM_BACKUPS} -gt 0 ]; then
+#     echo "No CycleCloud logfile found.  But backups exist."
+#     NEEDS_RESTORE="true"
+# else
+#     echo "No CycleCloud logfile or backups.  Starting fresh..."
+#     NEEDS_RESTORE="false"
+# fi
+
+if [ -f "${CS_ROOT}/data/ads/initial_load.marker" ]; then
+    echo "CycleCloud data directory still contains ${CS_ROOT}/data/ads/initial_load.marker"
+    rm -f ${CS_ROOT}/data/ads/initial_load.marker
+
+    # If this is the first load of the container, then restore if backups available
+    if [ -d ${CS_ROOT}/data/backups ] && [ ${NUM_BACKUPS} -gt 0 ]; then
+        echo "CycleCloud backups exist."
+        NEEDS_RESTORE="true"
+    fi
+fi
+
+if [ "${NEEDS_RESTORE}" == "true" ]; then
+    echo "Will restore CycleCloud from latest backup..."
+    echo "yes" | ${CS_ROOT}/util/restore.sh
+fi
+
+# Now run or re-run the install script to ensure all accounts are configured
+# options : 
+#     DRYRUN="--dryrun" for testing
+#     NO_DEFAULT_ACCOUNT="--noDefaultAccount" to disable initial CycleCloud account creation
+#     CYCLECLOUD_PASSWORD="" to use a randomized password
 python3 /cs-install/scripts/cyclecloud_install.py --acceptTerms \
-    --useManagedIdentity --username=${CYCLECLOUD_USERNAME} --password="${CYCLECLOUD_PASSWORD}" --publickey="${CYCLECLOUD_USER_PUBKEY}" --storageAccount=${CYCLECLOUD_STORAGE} --resourceGroup=${CYCLECLOUD_RESOURCE_GROUP} ${DRYRUN}
+    --useManagedIdentity --username=${CYCLECLOUD_USERNAME} --password="${CYCLECLOUD_PASSWORD}" \
+    --publickey="${CYCLECLOUD_USER_PUBKEY}" --storageAccount=${CYCLECLOUD_STORAGE} \
+    --resourceGroup=${CYCLECLOUD_RESOURCE_GROUP} ${DRYRUN} ${NO_DEFAULT_ACCOUNT}
 
 
 #keep Container alive permanently

--- a/docker/cyclecloud8/scripts/run_cyclecloud.sh
+++ b/docker/cyclecloud8/scripts/run_cyclecloud.sh
@@ -57,10 +57,13 @@ fi
 #     DRYRUN="--dryrun" for testing
 #     NO_DEFAULT_ACCOUNT="--noDefaultAccount" to disable initial CycleCloud account creation
 #     CYCLECLOUD_PASSWORD="" to use a randomized password
+#     CYCLECLOUD_HOSTNAME="X.X.X.X" to use a specific hostname or IP for clusternode-to-cyclecloud connections
 python3 /cs-install/scripts/cyclecloud_install.py --acceptTerms \
     --useManagedIdentity --username=${CYCLECLOUD_USERNAME} --password="${CYCLECLOUD_PASSWORD}" \
     --publickey="${CYCLECLOUD_USER_PUBKEY}" --storageAccount=${CYCLECLOUD_STORAGE} \
-    --resourceGroup=${CYCLECLOUD_RESOURCE_GROUP} ${DRYRUN} ${NO_DEFAULT_ACCOUNT}
+    --resourceGroup=${CYCLECLOUD_RESOURCE_GROUP} ${DRYRUN} ${NO_DEFAULT_ACCOUNT} \
+    --webServerMaxHeapSize=4096M --webServerPort=8080 --webServerSslPort=8443 \
+    --webServerClusterPort=9443 --webServerHostname="${CYCLECLOUD_HOSTNAME}"
 
 
 #keep Container alive permanently


### PR DESCRIPTION
Allow upgrading the pod without deleting the deployement/stateful-set
Allow passing a static hostname for the service to the cluster nodes so that cluster nodes can connect to CycleCloud via a stable hostname rather than out-of-date PrivateIP during a failover (alternatively, clusters may choose to use ReturnProxy) 